### PR TITLE
Bump version of MaryTTS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: korerorero-tts:latest
     container_name: korerorero-tts
     build:
-      context: https://github.com/ServiceInnovationLab/korerorero-marytts.git#v1.0.0
+      context: https://github.com/ServiceInnovationLab/korerorero-marytts.git#v1.0.1
     volumes:
       - ./build:/build
     networks:


### PR DESCRIPTION
MaryTTS has a new SemVer because of changes to documentation. This PR makes the reverse-proxy request that version.